### PR TITLE
fix: navigate to playing screen after confirming score for non-final board

### DIFF
--- a/index.html
+++ b/index.html
@@ -1304,7 +1304,7 @@
         declarer: '',
         tricksTaken: null
       };
-      render();
+      changeScreen('playing');
     }
 
     async function loadGameData() {


### PR DESCRIPTION
When confirming a score for a board that isn't the last in the round, the code was calling render() while state.screen was still 'scoreConfirmation'. This caused the confirmation screen to re-render with null values instead of navigating back to the playing screen for the next board.

Fixes #1

Generated with [Claude Code](https://claude.ai/code)