### PR TITLE
fix: navigate to playing screen after confirming score for non-final board

### DIFF
--- a/index.html
+++ b/index.html
@@ -1304,7 +1304,7 @@
         declarer: '',
         tricksTaken: null
       };
-      render();
+      changeScreen('playing');
     }
 
     async function loadGameData() {


### PR DESCRIPTION
When confirming a score for a board that isn't the last in the round, the code was calling render() while state.screen was still 'scoreConfirmation'. This caused the confirmation screen to re-render with null values instead of navigating back to the playing screen for the next board.

### Root Cause

In saveScore(), after advancing to the next board, render() was called but state.screen was still 'scoreConfirmation'. This caused:
1. Incorrect navigation (stays on confirmation screen instead of going to score entry)
2. Allows entry of a null score for the next board

### Fix

Changed render() → changeScreen('playing') so the app correctly navigates to the score entry screen after confirming a non-final board score.

Fixes #1

Generated with [Claude Code](https://claude.ai/code)