### PR TITLE
fix: restore auto-refresh checkbox state after re-render

### DIFF
--- a/index.html
+++ b/index.html
@@ -3189,7 +3189,8 @@
                 🔄 Refresh
               </button>
               <label style="display: flex; align-items: center; gap: 0.5rem; color: #b8b8d8; font-size: 0.9rem; cursor: pointer; white-space: nowrap;">
-                <input type="checkbox" id="auto-refresh-checkbox" onchange="toggleAutoRefresh(this.checked)" 
+                <input type="checkbox" id="auto-refresh-checkbox" onchange="toggleAutoRefresh(this.checked)"
+                       ${managementRefreshInterval ? 'checked' : ''}
                        style="cursor: pointer; width: 18px; height: 18px; flex-shrink: 0;">
                 Auto-refresh (15s)
               </label>


### PR DESCRIPTION
When auto-refresh triggers a render(), the management screen HTML is re-generated with a fresh unchecked checkbox, losing the checked state even though the interval is still running. This causes the duplicate interval bug when the user clicks the checkbox again.

Fixes #13

Generated with [Claude Code](https://claude.ai/code)