### PR TITLE
Update CLAUDE.md: TDD approach and testing guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,14 @@ Data is persisted in Redis.
 - `APP_URL` — Public URL of the deployment
 
 ## Testing
-- No automated tests yet — manual testing required
-- When fixing a bug, describe in the PR how you verified the fix works
+- **Write tests before making code changes** — follow a test-first (TDD) approach for all new functionality and bug fixes
+- New functionality: write unit or integration tests first, then implement the code to make them pass
+- Bug fixes: write a regression test that reproduces the bug first, then fix it
+- Use Node's built-in `node:test` runner (see `test/` directory for existing tests)
+- Pure logic (e.g. `lib/scoring.js`) goes in unit tests; route/Redis behaviour goes in integration tests
+- Every new API route must have at least one integration test
+- Tests run against a real Redis instance — no mocking
+- Run `npm test` to execute the test suite
 - Do not break existing API contracts — the frontend depends on exact response shapes
 
 ## Things to Be Careful About


### PR DESCRIPTION
Closes #21

Updates the `## Testing` section in CLAUDE.md to instruct Claude to write tests before making code changes (TDD).

Changes:
- Test-first (TDD) instruction as the top rule
- Separate guidance for new functionality vs bug fixes
- References to existing test infrastructure (`test/` dir, `node:test`, `npm test`)
- Requirement for integration test per new API route

Generated with [Claude Code](https://claude.ai/code)