### PR TITLE
feat: add Vite as frontend build tooling (#22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/app.js
+++ b/app.js
@@ -1,18 +1,18 @@
 import express from 'express';
-import { existsSync } from 'fs';
+import { existsSync } from 'node:fs';
 import { handler } from './server.js';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-// Serve from Vite's build output if available, otherwise fall back to project root
-const staticRoot = existsSync('./dist/index.html') ? 'dist' : '.';
+// Use Vite build output if available, otherwise fall back to source root
+const staticRoot = existsSync('./dist/index.html') ? './dist' : '.';
 console.log(`Serving static files from: ${staticRoot}`);
 
 // Parse JSON request bodies
 app.use(express.json());
 
-// Serve static files
+// Serve static files (Vite dist/ if built, otherwise source root)
 app.use(express.static(staticRoot));
 
 // Route all /api requests to your existing handler

--- a/app.js
+++ b/app.js
@@ -1,21 +1,26 @@
 import express from 'express';
+import { existsSync } from 'fs';
 import { handler } from './server.js';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+// Serve from Vite's build output if available, otherwise fall back to project root
+const staticRoot = existsSync('./dist/index.html') ? 'dist' : '.';
+console.log(`Serving static files from: ${staticRoot}`);
+
 // Parse JSON request bodies
 app.use(express.json());
 
-// Serve static files (your index.html etc)
-app.use(express.static('.'));
+// Serve static files
+app.use(express.static(staticRoot));
 
 // Route all /api requests to your existing handler
 app.all('/api/*', handler);
 
 // Fallback: serve index.html for everything else
 app.get('*', (req, res) => {
-  res.sendFile('index.html', { root: '.' });
+  res.sendFile('index.html', { root: staticRoot });
 });
 
 app.listen(PORT, () => {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "type": "module",
   "main": "app.js",
   "scripts": {
+    "start": "node app.js",
+    "start:vercel": "node server.js",
+    "test": "node --test --test-force-exit",
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
-    "start": "node app.js",
-    "start:vercel": "node server.js"
+    "preview": "vite preview"
   },
   "dependencies": {
     "express": "^4.18.0",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,18 @@
   "type": "module",
   "main": "app.js",
   "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
     "start": "node app.js",
     "start:vercel": "node server.js"
   },
   "dependencies": {
     "express": "^4.18.0",
     "redis": "^4.6.0"
+  },
+  "devDependencies": {
+    "vite": "^6.0.0"
   },
   "engines": {
     "node": "22.x"

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist',
+  },
+  server: {
+    // Proxy API calls to Express during Vite dev server
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,12 +6,8 @@ export default defineConfig({
     outDir: 'dist',
   },
   server: {
-    // Proxy API calls to Express during Vite dev server
     proxy: {
-      '/api': {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
-      },
+      '/api': 'http://localhost:3000',
     },
   },
 });


### PR DESCRIPTION
Add Vite as the frontend build tool as described in #22.

**Changes:**
- Add `vite ^6.0.0` as devDependency
- Add `npm run dev` (Vite dev server with /api proxy to Express), `npm run build`, `npm run preview` scripts
- Create `vite.config.js` with minimal config
- Update `app.js` to serve from `dist/` when Vite build output exists
- Add `dist/` to `.gitignore`

Closes #22

Generated with [Claude Code](https://claude.ai/code)