### PR TITLE
Add README maintenance instructions to CLAUDE.md and update README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,11 @@ Data is persisted in Redis.
 - Run `npm test` to execute the test suite
 - Do not break existing API contracts — the frontend depends on exact response shapes
 
+## README
+- Keep `README.md` up to date whenever you make changes that affect: features, API routes, environment variables, deployment, local development setup, or architecture
+- Update the README in the same PR as the code change — never leave them out of sync
+- The README is user-facing; write it for someone setting up or using the app, not for Claude
+
 ## Things to Be Careful About
 - Redis connection is lazy and shared — don't create multiple clients
 - Game state uses deepMerge for PATCH updates — understand this before modifying update logic

--- a/README.md
+++ b/README.md
@@ -11,19 +11,57 @@ A web application for scoring bridge games using Individual IMP scoring for 8 pl
 - Individual leaderboard
 - Round-by-round game summary
 
-## Deployment
+## Architecture
 
-This app is deployed on Vercel. To deploy updates:
-
-1. Make changes to the code
-2. Commit to GitHub: `git add . && git commit -m "Update description"`
-3. Push: `git push`
-4. Vercel will automatically deploy the changes
+- `app.js` — Express server entry point, listens on `PORT` (default 3000)
+- `server.js` — All API route handlers
+- `index.html` — Entire frontend (vanilla JS, no framework)
+- Redis — Sole data store (`REDIS_URL` environment variable)
 
 ## Local Development
 
+### Prerequisites
+
+- Node.js
+- A running Redis instance
+
+### Setup
+
 ```bash
-node server.js
+npm install
 ```
 
-Then open `http://localhost:3001` in your browser.
+Set the required environment variable:
+
+```bash
+export REDIS_URL=redis://localhost:6379
+```
+
+Start the server:
+
+```bash
+node app.js
+```
+
+Then open `http://localhost:3000` in your browser.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `REDIS_URL` | Yes | Redis connection string |
+| `PORT` | No | Server port (default: 3000) |
+| `NODE_ENV` | No | Environment name |
+
+## Deployment
+
+The app runs on OpenShift. Branches map to environments as follows:
+
+| Branch | Environment |
+|---|---|
+| `main` | Production (Vercel) |
+| `dev` | Integration (OpenShift) |
+| `qa` | Pre-prod (OpenShift) |
+| `claude` | Review (OpenShift, auto-deployed) |
+
+To deploy: open a PR from your branch to `dev`. Merging to `dev` triggers a deployment to the integration environment.


### PR DESCRIPTION
Adds a `## README` section to CLAUDE.md instructing Claude to keep the README in sync with code changes in the same PR.

Also corrects the README itself to reflect the current architecture (app.js entry point, port 3000, Redis setup, OpenShift deployment).

Fixes #28

Generated with [Claude Code](https://claude.ai/code)