### PR TITLE
Add test harness with scoring unit tests and API integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node app.js",
     "start:vercel": "node server.js",
-    "test": "node --test --test-force-exit"
+    "test": "node --test --test-force-exit",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "start:vercel": "node server.js"
+    "start:vercel": "node server.js",
+    "test": "node --test --test-force-exit"
   },
   "dependencies": {
     "express": "^4.18.0",

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,433 @@
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import express from 'express';
+import { handler } from '../server.js';
+import { getRedisClient } from '../lib/redis.js';
+
+let baseUrl;
+let server;
+const createdGameIds = [];
+
+function gameId() {
+  const id = `test-${randomUUID().slice(0, 8)}`;
+  createdGameIds.push(id);
+  return id;
+}
+
+async function api(path, options = {}) {
+  return fetch(`${baseUrl}${path}`, {
+    headers: { 'Content-Type': 'application/json', ...options.headers },
+    ...options,
+    body: options.body ? JSON.stringify(options.body) : undefined
+  });
+}
+
+before(async () => {
+  const app = express();
+  app.use(express.json());
+  app.all('/api/*', handler);
+
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      baseUrl = `http://localhost:${server.address().port}`;
+      resolve();
+    });
+  });
+});
+
+after(async () => {
+  if (createdGameIds.length > 0) {
+    const client = await getRedisClient();
+    for (const id of createdGameIds) {
+      await client.del(`game:${id}`);
+    }
+  }
+  await new Promise((resolve) => server.close(resolve));
+});
+
+describe('GET /api/version', () => {
+  test('returns version fields', async () => {
+    const res = await api('/api/version');
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok('buildId' in body);
+    assert.ok('deploymentUrl' in body);
+    assert.ok('environment' in body);
+    assert.ok('gitBranch' in body);
+  });
+});
+
+describe('POST /api/games', () => {
+  test('creates a game and returns 201', async () => {
+    const id = gameId();
+    const res = await api('/api/games', {
+      method: 'POST',
+      body: { gameId: id, currentRound: 1, boardsPerRound: 4 }
+    });
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.equal(body.gameId, id);
+  });
+
+  test('returns 400 when gameId is missing', async () => {
+    const res = await api('/api/games', {
+      method: 'POST',
+      body: { currentRound: 1 }
+    });
+    assert.equal(res.status, 400);
+  });
+});
+
+describe('GET /api/games/:id', () => {
+  test('returns the game after creation', async () => {
+    const id = gameId();
+    await api('/api/games', {
+      method: 'POST',
+      body: { gameId: id, currentRound: 1 }
+    });
+
+    const res = await api(`/api/games/${id}`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.gameId, id);
+    assert.equal(body.currentRound, 1);
+  });
+
+  test('returns 404 for unknown game', async () => {
+    const res = await api('/api/games/does-not-exist-xyz');
+    assert.equal(res.status, 404);
+  });
+
+  test('hides current-round scores from the other table', async () => {
+    const id = gameId();
+    // Create game with table 2 already having round 1 scores
+    await api('/api/games', {
+      method: 'POST',
+      body: {
+        gameId: id,
+        currentRound: 1,
+        boardsPerRound: 4,
+        tables: {
+          '1': { sessionId: 'session-t1' },
+          '2': {
+            sessionId: 'session-t2',
+            scores: {
+              '1': {
+                '1': { board: 1, level: 3, strain: 'NT', double: '', declarer: 'north', tricksTaken: 9 }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    // Table 1 requests the game — should see table 2's round 1 scores hidden
+    const res = await api(`/api/games/${id}`, {
+      headers: { 'x-table-number': '1' }
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const t2score = body.tables['2'].scores['1']['1'];
+    assert.equal(t2score.hidden, true, 'Table 2 current-round scores should be hidden from table 1');
+    assert.equal(t2score.board, 1, 'Board number should be preserved even when hidden');
+    assert.ok(!('level' in t2score), 'Score details should not be visible');
+  });
+
+  test('management session sees full unfiltered game', async () => {
+    const id = gameId();
+    await api('/api/games', {
+      method: 'POST',
+      body: {
+        gameId: id,
+        currentRound: 1,
+        boardsPerRound: 4,
+        managementSessionId: 'mgmt-session',
+        tables: {
+          '2': {
+            sessionId: 'session-t2',
+            scores: {
+              '1': {
+                '1': { board: 1, level: 3, strain: 'NT', double: '', declarer: 'north', tricksTaken: 9 }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    // Management requests game — scores should NOT be hidden
+    const res = await api(`/api/games/${id}?management=true`, {
+      headers: { 'x-management-session-id': 'mgmt-session' }
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const score = body.tables['2'].scores['1']['1'];
+    assert.equal(score.hidden, undefined, 'Scores should not be hidden for management session');
+    assert.equal(score.level, 3);
+  });
+
+  test('returns 423 when management is locked by another session', async () => {
+    const id = gameId();
+    await api('/api/games', {
+      method: 'POST',
+      body: { gameId: id, managementSessionId: 'session-A' }
+    });
+
+    const res = await api(`/api/games/${id}?management=true`, {
+      headers: { 'x-management-session-id': 'session-B' }
+    });
+    assert.equal(res.status, 423);
+  });
+});
+
+describe('PATCH /api/games/:id', () => {
+  test('updates game data via deep merge', async () => {
+    const id = gameId();
+    await api('/api/games', {
+      method: 'POST',
+      body: { gameId: id, currentRound: 1, boardsPerRound: 4, someField: 'original' }
+    });
+
+    const res = await api(`/api/games/${id}`, {
+      method: 'PATCH',
+      body: { newField: 'added' }
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.someField, 'original', 'Existing fields should be preserved');
+    assert.equal(body.newField, 'added');
+  });
+
+  test('returns 404 for unknown game', async () => {
+    const res = await api('/api/games/no-such-game', {
+      method: 'PATCH',
+      body: { someField: 'value' }
+    });
+    assert.equal(res.status, 404);
+  });
+
+  test('returns 403 when session is not authorized to update scores', async () => {
+    const id = gameId();
+    await api('/api/games', {
+      method: 'POST',
+      body: {
+        gameId: id,
+        currentRound: 1,
+        boardsPerRound: 4,
+        tables: { '1': { sessionId: 'correct-session' } }
+      }
+    });
+
+    const res = await api(`/api/games/${id}`, {
+      method: 'PATCH',
+      body: {
+        tables: {
+          '1': {
+            sessionId: 'wrong-session',
+            scores: { '1': { '1': { board: 1 } } }
+          }
+        }
+      }
+    });
+    assert.equal(res.status, 403);
+  });
+
+  test('management session can update any table scores', async () => {
+    const id = gameId();
+    await api('/api/games', {
+      method: 'POST',
+      body: {
+        gameId: id,
+        currentRound: 1,
+        boardsPerRound: 4,
+        managementSessionId: 'mgmt-session',
+        tables: { '1': { sessionId: 'table-session' } }
+      }
+    });
+
+    // Management updates table 1 scores without providing matching sessionId in body
+    const res = await api(`/api/games/${id}`, {
+      method: 'PATCH',
+      headers: { 'x-session-id': 'mgmt-session' },
+      body: {
+        tables: {
+          '1': {
+            sessionId: 'wrong-session',
+            scores: { '1': { '1': { board: 1, level: 1, strain: 'NT' } } }
+          }
+        }
+      }
+    });
+    assert.equal(res.status, 200);
+  });
+
+  test('returns 403 when advancing round without valid session', async () => {
+    const id = gameId();
+    await api('/api/games', {
+      method: 'POST',
+      body: { gameId: id, currentRound: 1, tables: { '1': { sessionId: 'session-t1' } } }
+    });
+
+    const res = await api(`/api/games/${id}`, {
+      method: 'PATCH',
+      headers: { 'x-session-id': 'wrong-session' },
+      body: { currentRound: 2 }
+    });
+    assert.equal(res.status, 403);
+  });
+
+  test('auto-advances currentRound when all boards are scored by both tables', async () => {
+    const id = gameId();
+    await api('/api/games', {
+      method: 'POST',
+      body: {
+        gameId: id,
+        currentRound: 1,
+        boardsPerRound: 4,
+        tables: {
+          '1': { sessionId: 'session-t1' },
+          '2': { sessionId: 'session-t2' }
+        }
+      }
+    });
+
+    const round1Scores = {
+      '1': { board: 1, level: 3, strain: 'NT', double: '', declarer: 'north', tricksTaken: 9 },
+      '2': { board: 2, level: 4, strain: 'S',  double: '', declarer: 'south', tricksTaken: 10 },
+      '3': { board: 3, level: 2, strain: 'H',  double: '', declarer: 'east',  tricksTaken: 8 },
+      '4': { board: 4, level: 3, strain: 'C',  double: '', declarer: 'west',  tricksTaken: 10 }
+    };
+
+    // Table 1 submits round 1 scores — should NOT auto-advance yet
+    const afterTable1 = await api(`/api/games/${id}`, {
+      method: 'PATCH',
+      body: { tables: { '1': { sessionId: 'session-t1', scores: { '1': round1Scores } } } }
+    });
+    const game1 = await afterTable1.json();
+    assert.equal(game1.currentRound, 1, 'Should not advance until table 2 also scores');
+
+    // Table 2 submits round 1 scores — should auto-advance
+    const afterTable2 = await api(`/api/games/${id}`, {
+      method: 'PATCH',
+      body: { tables: { '2': { sessionId: 'session-t2', scores: { '1': round1Scores } } } }
+    });
+    assert.equal(afterTable2.status, 200);
+    const game2 = await afterTable2.json();
+    assert.equal(game2.currentRound, 2, 'Should auto-advance to round 2 when both tables complete round 1');
+  });
+
+  test('management lock: acquire, block other session, release', async () => {
+    const id = gameId();
+    await api('/api/games', { method: 'POST', body: { gameId: id } });
+
+    // Acquire lock
+    const acquire = await api(`/api/games/${id}`, {
+      method: 'PATCH',
+      headers: { 'x-session-id': 'session-A' },
+      body: { managementSessionId: 'session-A' }
+    });
+    assert.equal(acquire.status, 200);
+
+    // Different session cannot acquire
+    const blocked = await api(`/api/games/${id}`, {
+      method: 'PATCH',
+      headers: { 'x-session-id': 'session-B' },
+      body: { managementSessionId: 'session-B' }
+    });
+    assert.equal(blocked.status, 423);
+
+    // Original session releases lock
+    const release = await api(`/api/games/${id}`, {
+      method: 'PATCH',
+      headers: { 'x-session-id': 'session-A' },
+      body: { managementSessionId: null }
+    });
+    assert.equal(release.status, 200);
+    const released = await release.json();
+    assert.equal(released.managementSessionId, undefined, 'Lock should be released');
+  });
+});
+
+describe('PUT /api/games/:id', () => {
+  test('replaces entire game state', async () => {
+    const id = gameId();
+    await api('/api/games', {
+      method: 'POST',
+      body: { gameId: id, currentRound: 1, someField: 'original' }
+    });
+
+    const res = await api(`/api/games/${id}`, {
+      method: 'PUT',
+      body: { gameId: id, currentRound: 2, replaced: true }
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.currentRound, 2);
+    assert.equal(body.replaced, true);
+    assert.equal(body.someField, undefined, 'PUT replaces entirely — old fields gone');
+  });
+});
+
+describe('full two-round game flow', () => {
+  test('both tables and a manager play through two complete rounds', async () => {
+    const id = gameId();
+
+    // Manager creates the game
+    await api('/api/games', {
+      method: 'POST',
+      body: {
+        gameId: id,
+        currentRound: 1,
+        boardsPerRound: 4,
+        managementSessionId: 'mgmt',
+        tables: {
+          '1': { sessionId: 'session-t1' },
+          '2': { sessionId: 'session-t2' }
+        }
+      }
+    });
+
+    // Build a helper to submit all 4 boards for a table in a given round
+    async function submitRound(tableNum, session, round) {
+      const base = (round - 1) * 4;
+      const scores = {};
+      for (let i = 1; i <= 4; i++) {
+        const board = base + i;
+        scores[String(board)] = {
+          board,
+          level: 3,
+          strain: 'NT',
+          double: '',
+          declarer: tableNum === '1' ? 'north' : 'east',
+          tricksTaken: 9
+        };
+      }
+      return api(`/api/games/${id}`, {
+        method: 'PATCH',
+        body: { tables: { [tableNum]: { sessionId: session, scores: { [round]: scores } } } }
+      });
+    }
+
+    // --- Round 1 ---
+    await submitRound('1', 'session-t1', 1);
+    const afterR1T2 = await submitRound('2', 'session-t2', 1);
+    const gameR1End = await afterR1T2.json();
+    assert.equal(afterR1T2.status, 200);
+    assert.equal(gameR1End.currentRound, 2, 'Game should auto-advance to round 2');
+
+    // Manager can see all scores from round 1
+    const mgmtView = await api(`/api/games/${id}?management=true`, {
+      headers: { 'x-management-session-id': 'mgmt' }
+    });
+    const mgmtGame = await mgmtView.json();
+    assert.equal(Object.keys(mgmtGame.tables['1'].scores['1']).length, 4, 'Table 1 should have 4 round-1 scores');
+    assert.equal(Object.keys(mgmtGame.tables['2'].scores['1']).length, 4, 'Table 2 should have 4 round-1 scores');
+
+    // --- Round 2 ---
+    await submitRound('1', 'session-t1', 2);
+    const afterR2T2 = await submitRound('2', 'session-t2', 2);
+    const gameR2End = await afterR2T2.json();
+    assert.equal(gameR2End.currentRound, 3, 'Game should auto-advance to round 3');
+  });
+});

--- a/test/scoring.test.js
+++ b/test/scoring.test.js
@@ -1,0 +1,260 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { calculateScore, calculateIMPs, calculateVPs } from '../lib/scoring.js';
+
+describe('calculateScore', () => {
+  describe('partial contracts (undoubled)', () => {
+    test('1NT made exactly by NS, board 1 (not vulnerable)', () => {
+      // baseScore: 40, partial bonus: +50
+      assert.equal(calculateScore(1, 'NT', '', 'north', 7, 1), 90);
+    });
+
+    test('2H made exactly by NS, board 1 (not vulnerable)', () => {
+      // baseScore: 2*30 = 60, partial bonus: +50
+      assert.equal(calculateScore(2, 'H', '', 'north', 8, 1), 110);
+    });
+
+    test('3C made exactly by NS, board 1 (not vulnerable)', () => {
+      // baseScore: 3*20 = 60, partial bonus: +50
+      assert.equal(calculateScore(3, 'C', '', 'north', 9, 1), 110);
+    });
+
+    test('3C+1 by NS, board 1 (not vulnerable)', () => {
+      // baseScore: 60, partial bonus: +50, overtrick (minor): +20
+      assert.equal(calculateScore(3, 'C', '', 'north', 10, 1), 130);
+    });
+  });
+
+  describe('game contracts (undoubled)', () => {
+    test('3NT made exactly by NS, board 1 (not vulnerable)', () => {
+      // baseScore: 40 + 2*30 = 100, game bonus NV: +300
+      assert.equal(calculateScore(3, 'NT', '', 'north', 9, 1), 400);
+    });
+
+    test('3NT made exactly by NS, board 2 (NS vulnerable)', () => {
+      // baseScore: 100, game bonus vul: +500
+      assert.equal(calculateScore(3, 'NT', '', 'north', 9, 2), 600);
+    });
+
+    test('3NT+1 by NS, board 1 (not vulnerable)', () => {
+      // baseScore: 100, game bonus NV: +300, overtrick (NT): +30
+      assert.equal(calculateScore(3, 'NT', '', 'north', 10, 1), 430);
+    });
+
+    test('4S made exactly by NS, board 1 (not vulnerable)', () => {
+      // baseScore: 4*30 = 120, game bonus NV: +300
+      assert.equal(calculateScore(4, 'S', '', 'north', 10, 1), 420);
+    });
+
+    test('4S made exactly by EW, board 1 (not vulnerable)', () => {
+      // EW declares and makes: NS perspective is negative
+      assert.equal(calculateScore(4, 'S', '', 'east', 10, 1), -420);
+    });
+
+    test('5D made exactly by NS, board 1 (not vulnerable)', () => {
+      // baseScore: 5*20 = 100, game bonus NV: +300
+      assert.equal(calculateScore(5, 'D', '', 'north', 11, 1), 400);
+    });
+  });
+
+  describe('slam contracts', () => {
+    test('6NT by NS, board 4 (both vulnerable)', () => {
+      // baseScore: 40 + 5*30 = 190, game bonus vul: +500, small slam vul: +750
+      assert.equal(calculateScore(6, 'NT', '', 'north', 12, 4), 1440);
+    });
+
+    test('6NT by NS, board 1 (not vulnerable)', () => {
+      // baseScore: 190, game bonus NV: +300, small slam NV: +500
+      assert.equal(calculateScore(6, 'NT', '', 'north', 12, 1), 990);
+    });
+
+    test('7NT by NS, board 4 (both vulnerable)', () => {
+      // baseScore: 40 + 6*30 = 220, game bonus vul: +500, grand slam vul: +1500
+      assert.equal(calculateScore(7, 'NT', '', 'north', 13, 4), 2220);
+    });
+
+    test('7NT by NS, board 1 (not vulnerable)', () => {
+      // baseScore: 220, game bonus NV: +300, grand slam NV: +1000
+      assert.equal(calculateScore(7, 'NT', '', 'north', 13, 1), 1520);
+    });
+
+    test('6S by EW, board 4 (both vulnerable)', () => {
+      // EW declares: NS gets negative
+      // baseScore: 6*30 = 180, game bonus vul: +500, small slam vul: +750
+      assert.equal(calculateScore(6, 'S', '', 'east', 12, 4), -1430);
+    });
+  });
+
+  describe('doubled and redoubled contracts (made)', () => {
+    test('2H doubled made exactly by NS, board 1 (not vulnerable)', () => {
+      // baseScore: 2*30*2 = 120, game bonus NV: +300, double bonus: +50
+      assert.equal(calculateScore(2, 'H', 'X', 'north', 8, 1), 470);
+    });
+
+    test('2H redoubled made exactly by NS, board 1 (not vulnerable)', () => {
+      // baseScore: 2*30*4 = 240, game bonus NV: +300, redouble bonus: +100
+      assert.equal(calculateScore(2, 'H', 'XX', 'north', 8, 1), 640);
+    });
+  });
+
+  describe('failed contracts (undertricks)', () => {
+    test('1NT down 1 by NS, board 1 (not vulnerable)', () => {
+      // Undoubled, NV: 50. NS declares, negative.
+      assert.equal(calculateScore(1, 'NT', '', 'north', 6, 1), -50);
+    });
+
+    test('1NT down 1 by NS, board 2 (NS vulnerable)', () => {
+      // Undoubled, vul: 100. NS declares, negative.
+      assert.equal(calculateScore(1, 'NT', '', 'north', 6, 2), -100);
+    });
+
+    test('1NT down 2 by NS, board 1 (not vulnerable)', () => {
+      // Undoubled, NV: 2*50 = 100.
+      assert.equal(calculateScore(1, 'NT', '', 'north', 5, 1), -100);
+    });
+
+    test('1NT down 1 doubled by NS, board 1 (not vulnerable)', () => {
+      // Doubled NV, 1 trick: 100.
+      assert.equal(calculateScore(1, 'NT', 'X', 'north', 6, 1), -100);
+    });
+
+    test('1NT down 2 doubled by NS, board 1 (not vulnerable)', () => {
+      // Doubled NV, 2 tricks: 300.
+      assert.equal(calculateScore(1, 'NT', 'X', 'north', 5, 1), -300);
+    });
+
+    test('1NT down 3 doubled by NS, board 1 (not vulnerable)', () => {
+      // Doubled NV, 3 tricks: 300 + 300 = 500. (300 + (3-2)*300)
+      assert.equal(calculateScore(1, 'NT', 'X', 'north', 4, 1), -500);
+    });
+
+    test('1NT down 1 doubled by NS, board 2 (NS vulnerable)', () => {
+      // Doubled vul, 1 trick: 200.
+      assert.equal(calculateScore(1, 'NT', 'X', 'north', 6, 2), -200);
+    });
+
+    test('1NT down 2 doubled by NS, board 2 (NS vulnerable)', () => {
+      // Doubled vul, 2 tricks: 200 + 300 = 500.
+      assert.equal(calculateScore(1, 'NT', 'X', 'north', 5, 2), -500);
+    });
+
+    test('1NT down 1 redoubled by NS, board 1 (not vulnerable)', () => {
+      // Redoubled NV, 1 trick: 200.
+      assert.equal(calculateScore(1, 'NT', 'XX', 'north', 6, 1), -200);
+    });
+
+    test('1NT down 1 redoubled by NS, board 2 (NS vulnerable)', () => {
+      // Redoubled vul, 1 trick: 400.
+      assert.equal(calculateScore(1, 'NT', 'XX', 'north', 6, 2), -400);
+    });
+
+    test('1NT down 1 by EW, board 1 (not vulnerable)', () => {
+      // EW declares and goes down: NS perspective positive (defenders win).
+      assert.equal(calculateScore(1, 'NT', '', 'east', 6, 1), 50);
+    });
+  });
+
+  describe('vulnerability patterns from board number', () => {
+    test('board 1 is none vulnerable', () => {
+      // NV: 3NT scores 400 (not 600)
+      assert.equal(calculateScore(3, 'NT', '', 'north', 9, 1), 400);
+    });
+
+    test('board 2 is NS vulnerable', () => {
+      assert.equal(calculateScore(3, 'NT', '', 'north', 9, 2), 600);
+    });
+
+    test('board 3 is EW vulnerable', () => {
+      // EW vul: 3NT by east scores -600 from NS perspective
+      assert.equal(calculateScore(3, 'NT', '', 'east', 9, 3), -600);
+    });
+
+    test('board 4 is both vulnerable', () => {
+      assert.equal(calculateScore(3, 'NT', '', 'north', 9, 4), 600);
+    });
+
+    test('board 18 has the same vulnerability as board 2 (repeats every 16)', () => {
+      // (18-1) % 16 + 1 = 2 → NS vulnerable
+      assert.equal(calculateScore(3, 'NT', '', 'north', 9, 18), 600);
+    });
+
+    test('board 17 has the same vulnerability as board 1', () => {
+      assert.equal(calculateScore(3, 'NT', '', 'north', 9, 17), 400);
+    });
+  });
+});
+
+describe('calculateIMPs', () => {
+  test('0 score difference is 0 IMPs', () => {
+    assert.equal(calculateIMPs(0), 0);
+  });
+
+  test('positive differences map to correct IMP thresholds', () => {
+    assert.equal(calculateIMPs(10), 0);   // < 20 → 0
+    assert.equal(calculateIMPs(20), 1);   // 20 ≤ x < 50 → 1
+    assert.equal(calculateIMPs(49), 1);
+    assert.equal(calculateIMPs(50), 2);   // 50 ≤ x < 90 → 2
+    assert.equal(calculateIMPs(89), 2);
+    assert.equal(calculateIMPs(90), 3);   // 90 ≤ x < 130 → 3
+    assert.equal(calculateIMPs(420), 9);   // 370 ≤ x < 430 → 9 (typical game)
+    assert.equal(calculateIMPs(499), 10); // 430 ≤ x < 500 → 10
+    assert.equal(calculateIMPs(500), 11); // 500 ≤ x < 600 → 11
+  });
+
+  test('negative differences return negative IMPs', () => {
+    assert.equal(calculateIMPs(-50), -2);
+    assert.equal(calculateIMPs(-420), -9);
+    assert.equal(calculateIMPs(-600), -11);
+  });
+
+  test('large differences cap at 24 IMPs', () => {
+    assert.equal(calculateIMPs(4000), 24);
+    assert.equal(calculateIMPs(7650), 24);
+    assert.equal(calculateIMPs(-4000), -24);
+  });
+
+  test('common game score differences map to expected IMPs', () => {
+    // 3NT NV (400) vs 3NT NV (-400) = 800 point swing → 13 IMPs
+    assert.equal(calculateIMPs(800), 13);
+    // 1100 ≤ x < 1300 → 15 IMPs
+    assert.equal(calculateIMPs(1200), 15);
+  });
+});
+
+describe('calculateVPs', () => {
+  test('0 IMP difference gives 10/10', () => {
+    assert.deepEqual(calculateVPs(0), { team1VPs: 10.00, team2VPs: 10.00 });
+  });
+
+  test('positive IMP difference gives team1 more VPs', () => {
+    const result = calculateVPs(10);
+    assert.equal(result.team1VPs, 15.00);
+    assert.equal(result.team2VPs, 5.00);
+  });
+
+  test('negative IMP difference gives team2 more VPs', () => {
+    const result = calculateVPs(-10);
+    assert.equal(result.team1VPs, 5.00);
+    assert.equal(result.team2VPs, 15.00);
+  });
+
+  test('30 IMPs difference is the maximum (20/0)', () => {
+    assert.deepEqual(calculateVPs(30), { team1VPs: 20.00, team2VPs: 0.00 });
+  });
+
+  test('IMPs beyond 30 are capped at 20/0', () => {
+    assert.deepEqual(calculateVPs(50), { team1VPs: 20.00, team2VPs: 0.00 });
+    assert.deepEqual(calculateVPs(-50), { team1VPs: 0.00, team2VPs: 20.00 });
+  });
+
+  test('VP values always sum to 20', () => {
+    for (const imps of [1, 5, 15, 25, 30]) {
+      const { team1VPs, team2VPs } = calculateVPs(imps);
+      assert.equal(
+        parseFloat((team1VPs + team2VPs).toFixed(2)),
+        20.00,
+        `VPs should sum to 20 for ${imps} IMPs`
+      );
+    }
+  });
+});


### PR DESCRIPTION
Closes #21

Adds automated test suite using Node's built-in `node:test` runner.

## Changes

- `test/scoring.test.js`: unit tests for `calculateScore`, `calculateIMPs`, and `calculateVPs` — pure functions, no I/O
- `test/api.test.js`: integration tests for all API routes against a real Redis instance, including full two-round game flow, score hiding between tables, management session visibility, lock acquire/block/release, and authorization checks
- `package.json`: adds `npm test` script using `node --test --test-force-exit`

Generated with [Claude Code](https://claude.ai/code)