### PR TITLE
fix: repair two test suite bugs

### DIFF
--- a/test/api.test.js
+++ b/test/api.test.js
@@ -16,10 +16,11 @@ function gameId() {
 }
 
 async function api(path, options = {}) {
+  const { headers: extraHeaders, body, ...rest } = options;
   return fetch(`${baseUrl}${path}`, {
-    headers: { 'Content-Type': 'application/json', ...options.headers },
-    ...options,
-    body: options.body ? JSON.stringify(options.body) : undefined
+    headers: { 'Content-Type': 'application/json', ...extraHeaders },
+    ...rest,
+    body: body ? JSON.stringify(body) : undefined
   });
 }
 

--- a/test/scoring.test.js
+++ b/test/scoring.test.js
@@ -204,7 +204,7 @@ describe('calculateIMPs', () => {
   test('negative differences return negative IMPs', () => {
     assert.equal(calculateIMPs(-50), -2);
     assert.equal(calculateIMPs(-420), -9);
-    assert.equal(calculateIMPs(-600), -11);
+    assert.equal(calculateIMPs(-600), -12);
   });
 
   test('large differences cap at 24 IMPs', () => {


### PR DESCRIPTION
Two bugs in the test suite caused 3 test failures.

**Bug 1**: `api()` helper in `test/api.test.js` overwrote the `headers` key when `options.headers` was present, dropping `Content-Type: application/json`. Fixed by destructuring options before the fetch call.

**Bug 2**: `calculateIMPs(-600)` was asserted as -11, but per the WBF IMP scale 600–740 points = 12 IMPs. Fixed assertion to -12.

Closes #34

Generated with [Claude Code](https://claude.ai/code)