### PR TITLE
fix: correct non-vulnerable doubled/redoubled undertrick penalties

### DIFF
--- a/lib/scoring.js
+++ b/lib/scoring.js
@@ -37,14 +37,14 @@ export function calculateScore(level, strain, double, declarer, tricksTaken, boa
       if (vulnerable) {
         penalty = undertricks === 1 ? 200 : 200 + (undertricks - 1) * 300;
       } else {
-        penalty = undertricks === 1 ? 100 : undertricks === 2 ? 300 : 300 + (undertricks - 2) * 300;
+        penalty = undertricks === 1 ? 100 : undertricks <= 3 ? 100 + (undertricks - 1) * 200 : 500 + (undertricks - 3) * 300;
       }
     } else if (double === 'XX') {
       // Redoubled undertricks
       if (vulnerable) {
         penalty = undertricks === 1 ? 400 : 400 + (undertricks - 1) * 600;
       } else {
-        penalty = undertricks === 1 ? 200 : undertricks === 2 ? 600 : 600 + (undertricks - 2) * 600;
+        penalty = undertricks === 1 ? 200 : undertricks <= 3 ? 200 + (undertricks - 1) * 400 : 1000 + (undertricks - 3) * 600;
       }
     }
 

--- a/test/scoring.test.js
+++ b/test/scoring.test.js
@@ -124,8 +124,13 @@ describe('calculateScore', () => {
     });
 
     test('1NT down 3 doubled by NS, board 1 (not vulnerable)', () => {
-      // Doubled NV, 3 tricks: 300 + 300 = 500. (300 + (3-2)*300)
+      // Doubled NV: 1st=100, 2nd=200, 3rd=200 → 500
       assert.equal(calculateScore(1, 'NT', 'X', 'north', 4, 1), -500);
+    });
+
+    test('1NT down 4 doubled by NS, board 1 (not vulnerable)', () => {
+      // Doubled NV: 1st=100, 2nd=200, 3rd=200, 4th=300 → 800
+      assert.equal(calculateScore(1, 'NT', 'X', 'north', 3, 1), -800);
     });
 
     test('1NT down 1 doubled by NS, board 2 (NS vulnerable)', () => {
@@ -143,9 +148,34 @@ describe('calculateScore', () => {
       assert.equal(calculateScore(1, 'NT', 'XX', 'north', 6, 1), -200);
     });
 
+    test('1NT down 2 redoubled by NS, board 1 (not vulnerable)', () => {
+      // Redoubled NV: 1st=200, 2nd=400 → 600
+      assert.equal(calculateScore(1, 'NT', 'XX', 'north', 5, 1), -600);
+    });
+
+    test('1NT down 3 redoubled by NS, board 1 (not vulnerable)', () => {
+      // Redoubled NV: 1st=200, 2nd=400, 3rd=400 → 1000
+      assert.equal(calculateScore(1, 'NT', 'XX', 'north', 4, 1), -1000);
+    });
+
+    test('1NT down 4 redoubled by NS, board 1 (not vulnerable)', () => {
+      // Redoubled NV: 1st=200, 2nd=400, 3rd=400, 4th=600 → 1600
+      assert.equal(calculateScore(1, 'NT', 'XX', 'north', 3, 1), -1600);
+    });
+
     test('1NT down 1 redoubled by NS, board 2 (NS vulnerable)', () => {
       // Redoubled vul, 1 trick: 400.
       assert.equal(calculateScore(1, 'NT', 'XX', 'north', 6, 2), -400);
+    });
+
+    test('1NT down 2 redoubled by NS, board 2 (NS vulnerable)', () => {
+      // Redoubled vul: 1st=400, 2nd=600 → 1000
+      assert.equal(calculateScore(1, 'NT', 'XX', 'north', 5, 2), -1000);
+    });
+
+    test('1NT down 3 doubled by NS, board 2 (NS vulnerable)', () => {
+      // Doubled vul: 1st=200, 2nd=300, 3rd=300 → 800
+      assert.equal(calculateScore(1, 'NT', 'X', 'north', 4, 2), -800);
     });
 
     test('1NT down 1 by EW, board 1 (not vulnerable)', () => {


### PR DESCRIPTION
Per WBF rules, the 3rd undertrick (non-vulnerable doubled) is 200, not 300. Fixes the NV doubled and NV redoubled undertrick formulas and adds regression tests for 4-down doubled NV and 2/3/4-down redoubled scenarios.

Fixes #33

Generated with [Claude Code](https://claude.ai/code)