### PR TITLE
fix: add default export to server.js for Vercel compatibility

### DIFF
--- a/server.js
+++ b/server.js
@@ -31,3 +31,5 @@ export async function handler(req, res) {
     });
   }
 }
+
+export default handler;


### PR DESCRIPTION
Vercel's @vercel/node builder requires a default export from the handler file. server.js only had a named export, causing preview deployments to fail with "Invalid export found".

Adds `export default handler;` at the end of server.js. The existing named export is preserved for the test suite.

Closes #37

Generated with [Claude Code](https://claude.ai/code)